### PR TITLE
Julia 0.7

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          git \
          curl \
          vim \
+		 pkg-config \
 	 emacs \
          parallel \
          ca-certificates \
@@ -18,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN mkdir ~/.parallel && touch ~/.parallel/will-cite
 
-RUN curl -o ~/miniconda.sh -L -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN curl -o ~/miniconda.sh -L -O https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \     
      rm ~/miniconda.sh && \
@@ -28,6 +29,7 @@ RUN curl -o ~/miniconda.sh -L -O  https://repo.continuum.io/miniconda/Miniconda3
 ENV PATH /opt/conda/bin:$PATH
 # This must be done before pip so that requirements.txt is available
 WORKDIR /opt/pytorch
+RUN conda install -y pytorch=0.4.1 -c pytorch
 COPY . .
 #RUN conda install pytorch torchvision -c pytorch
 
@@ -37,6 +39,7 @@ COPY . .
 ADD requirements.txt /app/
 WORKDIR /app
 #RUN --mount=type=cache,id=custom-pip,target=/root/.cache/pip pip cache list
+RUN python -m pip install --upgrade pip setuptools wheel
 RUN --mount=type=cache,id=custom-pip,target=/root/.cache/pip pip install -r requirements.txt
 
 ADD . /app 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -31,14 +31,12 @@ ENV PATH /opt/conda/bin:$PATH
 WORKDIR /opt/pytorch
 RUN conda install -y pytorch=0.4.1 -c pytorch
 COPY . .
-#RUN conda install pytorch torchvision -c pytorch
 
 #
 # Now install the julia dependencies.
 #
 ADD requirements.txt /app/
 WORKDIR /app
-#RUN --mount=type=cache,id=custom-pip,target=/root/.cache/pip pip cache list
 RUN python -m pip install --upgrade pip setuptools wheel
 RUN --mount=type=cache,id=custom-pip,target=/root/.cache/pip pip install -r requirements.txt
 
@@ -51,7 +49,6 @@ RUN apt-get update && apt-get install -y curl
 RUN mkdir /julia
 RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz | tar -C /julia --strip-components=1  -xzf -
 ENV PATH "/julia/bin:$PATH"
-#RUN julia -e "using Pkg; Pkg.init()"
 COPY setup.jl /julia/setup.jl
 RUN julia /julia/setup.jl
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-# PyTorch Install
+# syntax = docker/dockerfile:experimental
 FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN mkdir ~/.parallel && touch ~/.parallel/will-cite
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN curl -o ~/miniconda.sh -L -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \     
      rm ~/miniconda.sh && \
@@ -29,20 +29,26 @@ ENV PATH /opt/conda/bin:$PATH
 # This must be done before pip so that requirements.txt is available
 WORKDIR /opt/pytorch
 COPY . .
-RUN conda install pytorch torchvision -c pytorch
+#RUN conda install pytorch torchvision -c pytorch
 
 #
 # Now install the julia dependencies.
 #
+ADD requirements.txt /app/
+WORKDIR /app
+#RUN --mount=type=cache,id=custom-pip,target=/root/.cache/pip pip cache list
+RUN --mount=type=cache,id=custom-pip,target=/root/.cache/pip pip install -r requirements.txt
+
+ADD . /app 
+
 WORKDIR /opt/julia
-RUN pip install pandas matplotlib utils argh biopython
 RUN conda install networkx joblib
 
 RUN apt-get update && apt-get install -y curl
 RUN mkdir /julia
-RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.2-linux-x86_64.tar.gz | tar -C /julia --strip-components=1  -xzf -
+RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.5-linux-x86_64.tar.gz | tar -C /julia --strip-components=1  -xzf -
 ENV PATH "/julia/bin:$PATH"
-RUN julia -e "Pkg.init()"
+#RUN julia -e "using Pkg; Pkg.init()"
 COPY setup.jl /julia/setup.jl
 RUN julia /julia/setup.jl
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -46,7 +46,7 @@ RUN conda install networkx joblib
 
 RUN apt-get update && apt-get install -y curl
 RUN mkdir /julia
-RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.5-linux-x86_64.tar.gz | tar -C /julia --strip-components=1  -xzf -
+RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz | tar -C /julia --strip-components=1  -xzf -
 ENV PATH "/julia/bin:$PATH"
 #RUN julia -e "using Pkg; Pkg.init()"
 COPY setup.jl /julia/setup.jl

--- a/Docker/build.sh
+++ b/Docker/build.sh
@@ -1,1 +1,2 @@
+export DOCKER_BUILDKIT=1
 docker build -t hyperbolics/gpu .

--- a/Docker/requirements.txt
+++ b/Docker/requirements.txt
@@ -3,4 +3,3 @@ matplotlib
 utils
 argh
 biopython
-torchvision

--- a/Docker/requirements.txt
+++ b/Docker/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+matplotlib
+utils
+argh
+biopython
+torchvision

--- a/Docker/setup.jl
+++ b/Docker/setup.jl
@@ -3,6 +3,7 @@ Pkg.add("Pandas")
 Pkg.add("JLD")
 Pkg.add("PyCall")
 Pkg.add("SpecialFunctions")
+
 # Force compile
 using Pandas
 using JLD

--- a/Docker/setup.jl
+++ b/Docker/setup.jl
@@ -1,9 +1,11 @@
-Pkg.init()
+import Pkg
 Pkg.add("Pandas")
 Pkg.add("JLD")
+Pkg.add("PyCall")
 # Force compile
 using Pandas
 using JLD
+using Distributed
 
 Pkg.add("ArgParse")
 

--- a/Docker/setup.jl
+++ b/Docker/setup.jl
@@ -2,6 +2,7 @@ import Pkg
 Pkg.add("Pandas")
 Pkg.add("JLD")
 Pkg.add("PyCall")
+Pkg.add("SpecialFunctions")
 # Force compile
 using Pandas
 using JLD

--- a/combinatorial/comb.jl
+++ b/combinatorial/comb.jl
@@ -3,6 +3,10 @@ using JLD
 using ArgParse
 using Pandas
 using Distributed
+using LinearAlgebra
+using Random
+using SpecialFunctions
+
 @pyimport networkx as nx
 @pyimport scipy.sparse.csgraph as csg
 @pyimport numpy as np

--- a/combinatorial/rdim.jl
+++ b/combinatorial/rdim.jl
@@ -199,9 +199,9 @@ function place_children(dim, c, use_sp, sp, sample_from, sb)
     else
         # surface area of a hypersphere, since we tile it with K hypercubes
         if N%2 == 1
-            AN = N*2^N*pi^((N-1)/2)*factorial((N-1)/2)/factorial(N)
+            AN = N*2^N*pi^((N-1)/2)*SpecialFunctions.factorial((N-1)/2)/SpecialFunctions.factorial(N)
         else
-            AN = N*pi^(N/2)/(factorial(N/2))
+            AN = N*pi^(N/2)/(SpecialFunctions.factorial(N/2))
         end
 
         # approximate edge length for N-1 dimensional hypercube

--- a/combinatorial/utilities.jl
+++ b/combinatorial/utilities.jl
@@ -1,6 +1,6 @@
 # utilities.jl
 # various functions needed for combinatorial embeddings
-unshift!(PyVector(pyimport("sys")["path"]), "combinatorial")
+pushfirst!(PyVector(pyimport("sys")["path"]), "combinatorial")
 @pyimport utils.vis as vis
 @pyimport matplotlib.pyplot as plt
 
@@ -20,8 +20,8 @@ end
 
 # Express a hyperbolic distance in the unit disk
 function hyp_to_euc_dist(x)
-    return sqrt.((cosh.(x)-big(1))./(cosh.(x)+big(1)))
-    # return (exp.(x)-big(1))./(exp.(x)+big(1))
+    return sqrt.((cosh.(x).-big(1))./(cosh.(x).+big(1)))
+    # return (exp.(x).-big(1))./(exp.(x).+big(1))
 end
 
 # Place children

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,1 +1,1 @@
-nvidia-docker run -v "$PWD:/root/hyperbolics" -it hyperbolics/gpu /bin/bash
+docker run -v "$PWD:/root/hyperbolics" -it hyperbolics/gpu /bin/bash

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,1 +1,1 @@
-docker run -v "$PWD:/root/hyperbolics" -it hyperbolics/gpu /bin/bash
+nvidia-docker run -v "$PWD:/root/hyperbolics" -it hyperbolics/gpu /bin/bash


### PR DESCRIPTION
Hi all!
This repository contains Julia code in version 0.6 which is not supported anymore by packages such as pandas afaik. 
I therefore bumped up the requirement to Julia 0.7 and modified the code accordingly. I stuck to obvious changes (vectorization functions, `unshift!` replaced by `pushfirst!` and deprecated `tic` and `toc` functions.
 I am not familiar with Julia and therefore did not dig into the additional deprecation warnings but these minimal changes allow to build the docker image again. 
Dockerfile was also updated accordingly and I added additional caching of the pip wheels. 